### PR TITLE
Extract alloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,3 +97,6 @@ if(OPTSCHED_INCLUDE_TESTS)
       -O3
   )
 endif()
+
+add_compile_options(-Wno-suggest-override)
+add_compile_options(-Wno-inconsistent-missing-override)

--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -36,8 +36,8 @@ public:
                InstCount upperBound, SchedPriorities priorities, bool vrfySched,
                bool IsPostBB, int SolverID);
   virtual ~ACOScheduler();
-  FUNC_RESULT FindSchedule(InstSchedule *schedule, SchedRegion *region);
-  inline void UpdtRdyLst_(InstCount cycleNum, int slotNum);
+  FUNC_RESULT FindSchedule(InstSchedule *schedule, SchedRegion *region) override;
+  inline void UpdtRdyLst_(InstCount cycleNum, int slotNum) override;
   // Set the initial schedule for ACO
   // Default is NULL if none are set.
   void setInitialSched(InstSchedule *Sched);

--- a/include/opt-sched/Scheduler/bb_thread.h
+++ b/include/opt-sched/Scheduler/bb_thread.h
@@ -223,6 +223,19 @@ public:
   // Global Pool Nodes explored
   uint64_t GlobalPoolNodes = 0;
 
+  int *RegCrntUseCnts;
+  int *RegNums;
+  int16_t *RegTypes;
+
+  struct RegFields {
+    int CrntUseCnt;
+    int Num;
+    int Type;
+  };
+
+  DenseMap<llvm::opt_sched::Register *, RegFields> RegToFields;
+
+  void resetRegFields();
   // Allocate register structures needed to track cost
   void setupForSchdulng();
   // Initialize cost and register information (e.g register pressure)
@@ -253,6 +266,7 @@ public:
   bool chkCostFsblty(InstCount trgtLngth, EnumTreeNode *&treeNode, bool isGlobalPoolNode = false);
   // Not Implemented
   bool chkInstLgltyBBThread(SchedInstruction *inst);
+  inline RegFields getRegFields(Register *reg) {return RegToFields[reg];}
   // Returns the spill cost from last partial schedule cost calculation
   inline InstCount getCrntSpillCost() {return CrntSpillCost_;}
   // Returns the peak spill cost from last partial schedule cost calculation
@@ -441,6 +455,8 @@ public:
     static InstCount ComputeSLILStaticLowerBound(int64_t regTypeCnt_,
                                                  RegisterFile *regFiles_, 
                                                  DataDepGraph *dataDepGraph_);
+
+    //RegFields getRegFields(Register *reg) override {return RegToFields[reg];}
 
     bool isSecondPass() override { return isSecondPass_; }
 
@@ -702,6 +718,8 @@ public:
     inline void setMasterImprvCount(int *ImprvCount) {MasterImprvCount_ = ImprvCount; }
 
     inline void setRegionSchedule(InstSchedule *RegionSched) {RegionSched_ = RegionSched;}
+
+    //RegFields getRegFields(Register *reg) override {return RegToFields[reg];}
 
     void histTableLock(UDT_HASHVAL key) override;
     void histTableUnlock(UDT_HASHVAL key) override; 

--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -187,6 +187,9 @@ public:
 
   virtual ~DataDepGraph();
 
+
+    MachineFunction *MF_ = nullptr;
+
   void resetThreadWriteFields(int SolverID = -1, bool full = true);
 
   // Reads the data dependence graph from a text file.
@@ -203,10 +206,10 @@ public:
   float GetWeight() const;
 
   // Given an instruction number, return a pointer to the instruction object.
-  SchedInstruction *GetInstByIndx(InstCount instIndx);
+  SchedInstruction *GetInstByIndx(InstCount instIndx) override;
 
-  SchedInstruction *GetInstByTplgclOrdr(InstCount ordr);
-  SchedInstruction *GetInstByRvrsTplgclOrdr(InstCount ordr);
+  SchedInstruction *GetInstByTplgclOrdr(InstCount ordr) override;
+  SchedInstruction *GetInstByRvrsTplgclOrdr(InstCount ordr) override;
 
   // Setup the Dep. Graph for scheduling by doing a topological sort
   // followed by critical path computation
@@ -224,8 +227,8 @@ public:
   void GetCrntLwrBounds(DIRECTION dir, InstCount crntlwrBounds[], int SolverID);
   void SetCrntLwrBounds(DIRECTION dir, InstCount crntlwrBounds[], int SolverID);
 
-  SchedInstruction *GetRootInst();
-  SchedInstruction *GetLeafInst();
+  SchedInstruction *GetRootInst() override;
+  SchedInstruction *GetLeafInst() override;
 
   UDT_GLABEL GetMaxLtncySum();
   UDT_GLABEL GetMaxLtncy();
@@ -267,16 +270,16 @@ public:
   void CountDeps(InstCount &totDepCnt, InstCount &crossDepCnt, int SolverID);
 
   int GetBscBlkCnt();
-  bool IsInGraph(SchedInstruction *inst);
-  InstCount GetInstIndx(SchedInstruction *inst);
+  bool IsInGraph(SchedInstruction *inst) override;
+  InstCount GetInstIndx(SchedInstruction *inst) override;
   InstCount GetRltvCrtclPath(SchedInstruction *ref, SchedInstruction *inst,
-                             DIRECTION dir);
+                             DIRECTION dir) override;
   void SetCrntFrwrdLwrBound(SchedInstruction *inst, int SolverID);
   void SetSttcLwrBounds();
   void SetDynmcLwrBounds();
   void CreateEdge(SchedInstruction *frmNode, SchedInstruction *toNode,
                   int ltncy, DependenceType depType);
-  InstCount GetDistFrmLeaf(SchedInstruction *inst, int SolverID = INVALID_VALUE);
+  InstCount GetDistFrmLeaf(SchedInstruction *inst, int SolverID = INVALID_VALUE) override;
 
   void SetPrblmtc();
   bool IsPrblmtc();
@@ -350,7 +353,6 @@ protected:
   SmallVector<std::unique_ptr<GraphTrans>, 0> graphTrans_;
 
   MachineModel *machMdl_;
-  MachineFunction *MF_ = nullptr;
 
   bool backTrackEnbl_;
 

--- a/include/opt-sched/Scheduler/enumerator.h
+++ b/include/opt-sched/Scheduler/enumerator.h
@@ -1317,7 +1317,7 @@ inline void Enumerator::UpdtRdyLst_(InstCount cycleNum, int slotNum) {
   LinkedList<SchedInstruction> *lst2 = frstRdyLstPerCycle_[cycleNum];
 
   if (prirts_.isDynmc)
-    rdyLst_->UpdatePriorities();
+    rdyLst_->UpdatePriorities(bbt_);
 
   if (slotNum == 0 && prevCycleNum >= 0) {
     // If at the begining of a new cycle other than the very first cycle, then
@@ -1328,7 +1328,7 @@ inline void Enumerator::UpdtRdyLst_(InstCount cycleNum, int slotNum) {
   }
 
   
-  rdyLst_->AddLatestSubLists(lst1, lst2);
+  rdyLst_->AddLatestSubLists(lst1, lst2, bbt_);
 }
 /*****************************************************************************/
 

--- a/include/opt-sched/Scheduler/gen_sched.h
+++ b/include/opt-sched/Scheduler/gen_sched.h
@@ -121,6 +121,9 @@ public:
 
   // Calculates the schedule and returns it in the passed argument.
   virtual FUNC_RESULT FindSchedule(InstSchedule *sched, SchedRegion *rgn) = 0;
+  // A pointer to the branch and bound instance. Needed to reference variables that
+  // are static across multiple enumeration trees (e.g. best cost so far)
+  BBThread *bbt_;
 
 protected:
   // The data dependence graph to be scheduled.
@@ -161,10 +164,6 @@ protected:
   ReserveSlot *rsrvSlots_;
   // The number of elements in rsrvSlots_.
   int16_t rsrvSlotCnt_;
-
-  // A pointer to the branch and bound instance. Needed to reference variables that
-  // are static across multiple enumeration trees (e.g. best cost so far)
-  BBThread *bbt_;
 
   SchedPriorities prirts_;
 

--- a/include/opt-sched/Scheduler/hash_table.h
+++ b/include/opt-sched/Scheduler/hash_table.h
@@ -63,10 +63,10 @@ public:
   BinHashTblEntry();
   ~BinHashTblEntry() {}
   void Construct(UDT_HASHKEY key, T *_elmnt, UDT_HASHVAL hashVal);
-  void Clean() {}
+  void Clean() override {Logger::Info("in binhastblentry clean\n");}
 
   UDT_HASHKEY GetKey();
-  UDT_HASHVAL GetHashVal();
+  UDT_HASHVAL GetHashVal() override;
 
 private:
   UDT_HASHKEY key_; // A binary key value
@@ -153,7 +153,7 @@ public:
                UDT_HASHTBL_CPCTY maxEntryCnt = DFLT_HASHTBL_CPCTY);
   ~BinHashTable();
 
-  void Clear(bool del, MemAlloc<BinHashTblEntry<T>> *entryAlctr = NULL);
+  void Clear(bool del, MemAlloc<BinHashTblEntry<T>> *entryAlctr = NULL) override;
 
   HashTblEntry<T> *InsertElement(UDT_HASHKEY key, T *elmnt,
                                  MemAlloc<BinHashTblEntry<T>> *entryAlctr, BBThread *bbt);
@@ -418,8 +418,8 @@ template <class T> inline bool HashTable<T>::IsConstructed() {
 template <class T>
 void HashTable<T>::Clear(bool del, MemAlloc<BinHashTblEntry<T>> *entryAlctr) {
   UDT_HASHVAL i;
-  HashTblEntry<T> *crntEntry;
-  HashTblEntry<T> *nxtEntry;
+  //HashTblEntry<T> *crntEntry;
+  //HashTblEntry<T> *nxtEntry;
   assert(isCnstrctd_);
 
   if (entryCnt_ == 0) {
@@ -427,31 +427,33 @@ void HashTable<T>::Clear(bool del, MemAlloc<BinHashTblEntry<T>> *entryAlctr) {
   }
 
   for (i = 0; i <= maxHash_; i++) {
+    /*
     for (crntEntry = topEntry_[i]; crntEntry != NULL; crntEntry = nxtEntry) {
       nxtEntry = crntEntry->GetNxt();
 
       if (del) {
+        Logger::Info("del\n");
         delete crntEntry->GetElmnt();
       }
 
-      if (isExtrnlAlctr_) {
+      if (true || isExtrnlAlctr_) {
         assert(entryAlctr != NULL);
         crntEntry->Clean();
         // Under the assumption that the entire allocator will be freed right
         // after this, we do not need to free this object and put it in a
         // potentially huge linked list. Actually, that was found to cause a
         // serious memory over-allocation problem. [GOS 3.25.03]
-        // entryAlctr->FreeObject((BinHashTblEntry<T>*)crntEntry);
+  //      entryAlctr->FreeObject((BinHashTblEntry<T>*)crntEntry);
       } else {
         delete crntEntry;
       }
     }
-
+    */
     topEntry_[i] = NULL;
     lastEntry_[i] = NULL;
     entryCnts_[i] = 0;
   }
-
+  Logger::Info("after parsing lists in hist table\n");
   entryCnt_ = 0;
   ppultdBktCnt_ = 0;
   maxListSize_ = 0;

--- a/include/opt-sched/Scheduler/hist_table.h
+++ b/include/opt-sched/Scheduler/hist_table.h
@@ -174,7 +174,7 @@ protected:
   bool ChkCostDmntnForBBSpill_(EnumTreeNode *node, Enumerator *enumrtr);
   bool ChkCostDmntn_(EnumTreeNode *node, Enumerator *enumrtr,
                      InstCount &maxShft);
-  virtual void Init_();
+  virtual void Init_() override;
 };
 
 } // namespace opt_sched

--- a/include/opt-sched/Scheduler/list_sched.h
+++ b/include/opt-sched/Scheduler/list_sched.h
@@ -24,13 +24,13 @@ public:
   virtual ~ListScheduler();
 
   // Calculates the schedule and returns it in the passed argument.
-  FUNC_RESULT FindSchedule(InstSchedule *sched, SchedRegion *rgn);
+  FUNC_RESULT FindSchedule(InstSchedule *sched, SchedRegion *rgn) override;
 
 protected:
   bool isDynmcPrirty_;
   // Adds the instructions that have just become ready at this cycle to the
   // ready list.
-  void UpdtRdyLst_(InstCount cycleNum, int slotNum);
+  void UpdtRdyLst_(InstCount cycleNum, int slotNum) override;
 
   // Check whether the next node ID instruction is ready -- used to collect
   // scheduling stats for LLVM generating schedules

--- a/include/opt-sched/Scheduler/lnkd_lst.h
+++ b/include/opt-sched/Scheduler/lnkd_lst.h
@@ -61,8 +61,8 @@ template <class T, class K = unsigned long> struct KeyedEntry : Entry<T> {
     Entry<T>::next = entry->GetNext();
     Entry<T>::prev = entry->GetPrev();
   }
-  virtual KeyedEntry *GetNext() const { return (KeyedEntry *)Entry<T>::next; }
-  virtual KeyedEntry *GetPrev() const { return (KeyedEntry *)Entry<T>::prev; }
+  virtual KeyedEntry *GetNext() const override { return (KeyedEntry *)Entry<T>::next; }
+  virtual KeyedEntry *GetPrev() const override { return (KeyedEntry *)Entry<T>::prev; }
 };
 
 /**
@@ -228,6 +228,9 @@ public:
 
   // A virtual destructor, to support inheritance.
   virtual ~LinkedList();
+
+  // Resets the list to its initial state.
+  virtual void Init_();
   // Deletes all existing entries and resets the list to its initial state.
   virtual void Reset();
 
@@ -305,8 +308,6 @@ protected:
   // Removes a given entry from the list. If free = true, deletes it via
   // FreeEntry_().
   virtual void RmvEntry_(Entry<T> *entry, bool free = true);
-  // Resets all state to default values. Warning: does not free memory!
-  virtual void Init_();
   // Deletes an entry object in dynamically-sized lists.
   void FreeEntry_(Entry<T> *entry);
 
@@ -363,7 +364,7 @@ public:
   // element with the same key exists.
   KeyedEntry<T, K> *InsrtElmnt(T *elmnt, K key, bool allowDplct);
   // Disable the version from LinkedList.
-  void InsrtElmnt(T *) { llvm::report_fatal_error("Unimplemented.", false); }
+  void InsrtElmnt(T *) override { llvm::report_fatal_error("Unimplemented.", false); }
 
   T *ViewNxtPriorityElmnt();
 

--- a/include/opt-sched/Scheduler/mem_mngr.h
+++ b/include/opt-sched/Scheduler/mem_mngr.h
@@ -9,6 +9,7 @@ Last Update:  Mar. 2011
 #ifndef OPTSCHED_GENERIC_MEM_MNGR_H
 #define OPTSCHED_GENERIC_MEM_MNGR_H
 
+
 #include "opt-sched/Scheduler/defines.h"
 #include "opt-sched/Scheduler/lnkd_lst.h"
 #include "opt-sched/Scheduler/logger.h"
@@ -97,23 +98,22 @@ inline MemAlloc<T>::MemAlloc(int blockSize, int maxSize)
 }
 
 template <class T> inline MemAlloc<T>::~MemAlloc() {
+  Logger::Info("deleting memalloc");
   int i = 0;
-  //Logger::Info("in memalloc destructor");
   for (T *blk = allocatedBlocks_.GetFrstElmnt(); blk != NULL;
        blk = allocatedBlocks_.GetNxtElmnt()) {
     ++i;
     delete[] blk;
   }
 
-  //Logger::Info("deleted %d blocks", i);
+  Logger::Info("deleted %d blocks", i);
 }
 
 template <class T> inline void MemAlloc<T>::Reset() {
-  //Logger::Info("resetting hist allocator");
   assert(allocatedBlocks_.GetElmntCnt() >= 1);
   currentBlock_ = allocatedBlocks_.GetFrstElmnt();
   currentIndex_ = 0;
-  availableObjects_.Reset();
+  availableObjects_.Init_();
   allocatedBlocksAvailable_ = true;
 }
 
@@ -158,10 +158,6 @@ template <class T> inline T *MemAlloc<T>::GetObjects_(int count) {
     obj = currentBlock_ + currentIndex_;
     currentIndex_ += count;
   }
-
-  /*else {
-    Logger::Info("found an object already available");
-  }*/
 
   assert(obj != NULL);
   return obj;

--- a/include/opt-sched/Scheduler/ready_list.h
+++ b/include/opt-sched/Scheduler/ready_list.h
@@ -36,10 +36,10 @@ public:
   void Reset();
 
   // Adds an instruction to the ready list.
-  void AddInst(SchedInstruction *inst);
+  void AddInst(SchedInstruction *inst, BBThread *rgn);
 
   // Adds a list of instructions to the ready list.
-  void AddList(LinkedList<SchedInstruction> *lst);
+  void AddList(LinkedList<SchedInstruction> *lst, BBThread *rgn);
 
   // Get the element that iterator is currently pointing at without advancing
   SchedInstruction *viewNextPriorityInst();
@@ -68,7 +68,8 @@ public:
   // not been added to the ready list already, and advance the internal time.
   // TODO(max): Elaborate.
   void AddLatestSubLists(LinkedList<SchedInstruction> *lst1,
-                         LinkedList<SchedInstruction> *lst2);
+                         LinkedList<SchedInstruction> *lst2,
+                         BBThread *rgn);
 
   // Removes the most recently added sublist of instructions.
   // TODO(max): Elaborate.
@@ -83,7 +84,7 @@ public:
 
   // Update instruction priorities within the list
   // Called only if the priorities change dynamically during scheduling
-  void UpdatePriorities();
+  void UpdatePriorities(BBThread *rgn);
 
   unsigned long MaxPriority();
 
@@ -91,7 +92,7 @@ public:
   void Print(std::ostream &out);
 
   // Constructs the priority-list key based on the schemes listed in prirts_.
-  unsigned long CmputKey_(SchedInstruction *inst, bool isUpdate, bool &changed);
+  unsigned long CmputKey_(SchedInstruction *inst, bool isUpdate, bool &changed, BBThread *rgn = nullptr);
 
   // returns the priority list of instructions
   //inline PriorityList<SchedInstruction> getInstList() {return prirtyLst_;}
@@ -141,7 +142,7 @@ private:
 
   // Adds instructions at the bottom of a given list which have not been added
   // to the ready list already.
-  void AddLatestSubList_(LinkedList<SchedInstruction> *lst);
+  void AddLatestSubList_(LinkedList<SchedInstruction> *lst, BBThread *rgn);
 
   // Calculates a new priority key given an existing key of size keySize by
   // appending bitCnt bits holding the value val, assuming val < maxVal.

--- a/include/opt-sched/Scheduler/register.h
+++ b/include/opt-sched/Scheduler/register.h
@@ -44,7 +44,7 @@ public:
   int16_t GetType() const;
   void SetType(int16_t type);
 
-  int GetNum(int SolverID) const;
+  int GetNum(int SolverID = -1) const;
   void SetNum(int SolverID, int num);
 
   inline int getNumSolvers() {return NumSolvers_; }
@@ -105,7 +105,7 @@ public:
 
 private:
   int16_t type_;
-  //int num_;
+  int num_;
   int defCnt_;
   int useCnt_;
   paddedVals *cachedVals;
@@ -174,11 +174,13 @@ public:
   // Increase the size of the register file by one and
   // return the RegNum of the created register.
   Register *getNext();
+ 
+  SmallVector<std::shared_ptr<Register>, 8> getRegs() { return Regs;}
 
 private:
   int16_t regType_;
   int physRegCnt_;
-  mutable SmallVector<std::unique_ptr<Register>, 8> Regs;
+  mutable SmallVector<std::shared_ptr<Register>, 8> Regs;
   int NumSolvers_;
 };
 

--- a/include/opt-sched/Scheduler/relaxed_sched.h
+++ b/include/opt-sched/Scheduler/relaxed_sched.h
@@ -127,7 +127,7 @@ public:
   inline void Initialize(bool setPrirtyLst);
 
   // Find a feasible relaxed schedule of all instructions and return its length
-  InstCount FindSchedule();
+  InstCount FindSchedule() override;
 
   // Try to schedule all unscheduled instructions between the current cycle and
   // the given last cycle. Return true if this is feasible and false if not
@@ -161,7 +161,7 @@ private:
   // in the specified direction.
   InstCount SchdulSubGraph_(SchedInstruction *inst, DIRECTION dir);
 
-  InstCount CmputReleaseTime_(SchedInstruction *inst);
+  InstCount CmputReleaseTime_(SchedInstruction *inst) override;
 
 public:
   LC_RelaxedScheduler(DataDepStruct *dataDepGraph, MachineModel *machMdl,
@@ -169,7 +169,7 @@ public:
   ~LC_RelaxedScheduler();
 
   // Find a relaxed schedule of all instructions and return its length
-  InstCount FindSchedule();
+  InstCount FindSchedule() override;
 };
 /*****************************************************************************/
 
@@ -203,9 +203,9 @@ private:
   void InitCycleProbe_(SchedInstruction *newInst);
   bool CheckSlots_(InstCount firstCycle, InstCount lastCycle);
 
-  InstCount CmputReleaseTime_(SchedInstruction *inst);
+  InstCount CmputReleaseTime_(SchedInstruction *inst) override;
 
-  InstCount GetCrntLwrBound_(SchedInstruction *inst, DIRECTION dir);
+  InstCount GetCrntLwrBound_(SchedInstruction *inst, DIRECTION dir) override;
 
   void SetCrntLwrBound_(SchedInstruction *inst, DIRECTION dir,
                         InstCount newBound);
@@ -226,7 +226,7 @@ public:
 
   // Find a minimum-length relaxed schedule of all instructions and return its
   // length
-  InstCount FindSchedule();
+  InstCount FindSchedule() override;
 
   // Find a relaxed schedule of the given length
   // The Boolean determines whether the opposite direction has been probed and

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -501,7 +501,7 @@ public:
   // Computer the adjusted use count. Update "adjustedUseCnt_".
   void ComputeAdjustedUseCnt(SchedInstruction *inst);
 
-  int16_t CmputLastUseCnt(int SolverID);
+  int16_t CmputLastUseCnt(int SolverID, BBThread *rgn);
   int16_t GetLastUseCnt(int SolverID) { return DynamicFields_[SolverID].getLastUseCnt(); }
 
   InstType GetCrtclPathFrmRoot() { return crtclPathFrmRoot_; }

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -514,6 +514,10 @@ public:
 protected:
   MachineFunction *MF_;
   const SUnit *SU_;
+
+  bool isCP_FromScsr_ = false;
+  bool isCP_FromPrdcsr_ = false;
+
   // The "name" of this instruction. Usually a string indicating its type.
   string name_;
   // The mnemonic of this instruction, e.g. "add" or "jmp".

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -51,6 +51,9 @@ public:
               int16_t sigHashSize, LB_ALG lbAlg, SchedPriorities hurstcPrirts,
               SchedPriorities enumPrirts, bool vrfySched,
               Pruning PruningStrategy, SchedulerType HeurSchedType,
+              SmallVector<MemAlloc<EnumTreeNode> *, 16> &EnumNodeAllocs,
+              SmallVector<MemAlloc<CostHistEnumTreeNode> *, 16> &HistNodeAllocs, 
+               SmallVector<MemAlloc<BinHashTblEntry<HistEnumTreeNode>> *, 16> &HashTablAllocs,
               SPILL_COST_FUNCTION spillCostFunc = SCF_PERP);
   // Destroys the region. Must be overriden by child classes.
   virtual ~SchedRegion() {delete OptimalSolverID_;}
@@ -190,6 +193,10 @@ protected:
   // The absolute cost lower bound to be used as a ref for normalized costs.
   InstCount costLwrBound_ = 0;
 
+  SmallVector<MemAlloc<EnumTreeNode> *, 16> EnumNodeAllocs_;
+  SmallVector<MemAlloc<CostHistEnumTreeNode> *, 16> HistNodeAllocs_;
+  SmallVector<MemAlloc<BinHashTblEntry<HistEnumTreeNode>> *, 16> HashTablAllocs_;
+
   // protected accessors:
   SchedulerType GetHeuristicSchedulerType() const { return HeurSchedType_; }
 
@@ -233,7 +240,9 @@ protected:
   // TODO(max): Document.
   virtual void CmputSchedUprBound_() = 0;
   // TODO(max): Document.
-  virtual Enumerator *AllocEnumrtr_(Milliseconds timeout) = 0;
+  virtual Enumerator *AllocEnumrtr_(Milliseconds timeout, SmallVector<MemAlloc<EnumTreeNode> *, 16> &EnumNodeAllocs,
+             SmallVector<MemAlloc<CostHistEnumTreeNode> *, 16> &HistNodeAllocs, 
+             SmallVector<MemAlloc<BinHashTblEntry<HistEnumTreeNode>> *, 16> &HashTablAllocs) = 0;
   // Wrapper for the enumerator
   virtual FUNC_RESULT Enumerate_(Milliseconds startTime,
                                  Milliseconds rgnTimeout,

--- a/include/opt-sched/Scheduler/stats.h
+++ b/include/opt-sched/Scheduler/stats.h
@@ -90,7 +90,7 @@ public:
   T value_;
 
   // Prints the stat to a stream.
-  void Print(std::ostream &out) const {
+  void Print(std::ostream &out) const override{
     out << name_ << ": " << value_ << "\n";
   }
 
@@ -121,7 +121,7 @@ protected:
   // The maximum  of the recorded values.
   T max_;
   // Prints the stat to a stream.
-  void Print(std::ostream &out) const;
+  void Print(std::ostream &out) const override;
 };
 
 typedef DistributionStat<int64_t> IntDistributionStat;
@@ -139,7 +139,7 @@ protected:
   // The string tracked by this record.
   string value_;
   // Prints the stat to a stream.
-  void Print(std::ostream &out) const {
+  void Print(std::ostream &out) const override {
     out << name_ << ": " << value_ << "\n";
   }
 };
@@ -158,7 +158,7 @@ protected:
   // The values tracked by this record.
   std::set<T> values_;
   // Prints the stat to a stream.
-  void Print(std::ostream &out) const;
+  void Print(std::ostream &out) const override;
 };
 typedef SetStat<int64_t> IntSetStat;
 typedef SetStat<float> FloatSetStat;
@@ -181,7 +181,7 @@ protected:
   // The sets tracked by this record.
   std::map<string, std::set<T>> values_;
   // Prints the stat to a stream.
-  void Print(std::ostream &out) const;
+  void Print(std::ostream &out) const override;
 };
 
 typedef IndexedSetStat<int64_t> IndexedIntSetStat;
@@ -216,7 +216,7 @@ public:
 protected:
   std::list<Entry> entries_;
   // Prints the stat to a stream.
-  void Print(std::ostream &out) const;
+  void Print(std::ostream &out) const override;
 };
 
 // A record to keep track of a group of numerical values, indexed by strings.
@@ -251,7 +251,7 @@ protected:
   // The values tracked by this record.
   std::map<string, T> values_;
   // Prints the stat to a stream.
-  void Print(std::ostream &out) const;
+  void Print(std::ostream &out) const override;
 };
 
 typedef IndexedNumericStat<int64_t> IndexedIntStat;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -51,4 +51,4 @@ set(OPTSCHED_EXTRA_DEFINITIONS "-DINSERT_ON_STEPFRWRD")
 add_definitions(${OPTSCHED_EXTRA_DEFINITIONS})
 
 add_compile_options(-Wno-inconsistent-missing-override)
-
+add_compile_options(-Wno-suggest-override)

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -257,7 +257,7 @@ std::unique_ptr<InstSchedule> ACOScheduler::FindOneSchedule() {
         for (SchedInstruction *fIns = futureReady->GetFrstElmnt(); fIns;
              fIns = futureReady->GetNxtElmnt()) {
           bool changed;
-          unsigned long heuristic = rdyLst_->CmputKey_(fIns, false, changed);
+          unsigned long heuristic = rdyLst_->CmputKey_(fIns, false, changed, bbt_);
           Choice c;
           c.inst = fIns;
           c.heuristic = (double)heuristic / maxPriority + 1;
@@ -495,14 +495,14 @@ inline void ACOScheduler::UpdtRdyLst_(InstCount cycleNum, int slotNum) {
     lst1 = frstRdyLstPerCycle_[prevCycleNum];
 
     if (lst1 != NULL) {
-      rdyLst_->AddList(lst1);
+      rdyLst_->AddList(lst1, bbt_);
       lst1->Reset();
       CleanupCycle_(prevCycleNum);
     }
   }
 
   if (lst2 != NULL) {
-    rdyLst_->AddList(lst2);
+    rdyLst_->AddList(lst2, bbt_);
     lst2->Reset();
   }
 }

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -59,12 +59,8 @@ DataDepStruct::DataDepStruct(MachineModel *machMdl, const int NumSolvers) {
 
 DataDepStruct::~DataDepStruct() {
   delete[] instCntPerIssuType_;
-  if (frwrdLwrBounds_ != NULL) {
-    delete frwrdLwrBounds_;
-  }
-  if (bkwrdLwrBounds_ != NULL) {
-    delete bkwrdLwrBounds_;
-  }
+  delete[] frwrdLwrBounds_;
+  delete[] bkwrdLwrBounds_;
 }
 
 void DataDepStruct::GetInstCntPerIssuType(InstCount instCntPerIssuType[]) {
@@ -319,8 +315,8 @@ FUNC_RESULT DataDepGraph::UpdateSetupForSchdulng(bool cmputTrnstvClsr) {
   DepthFirstSearch();
 
 
-  delete frwrdLwrBounds_;
-  delete bkwrdLwrBounds_;
+  delete[] frwrdLwrBounds_;
+  delete[] bkwrdLwrBounds_;
 
   frwrdLwrBounds_ = new InstCount[instCnt_];
   bkwrdLwrBounds_ = new InstCount[instCnt_];

--- a/lib/Scheduler/enumerator.cpp
+++ b/lib/Scheduler/enumerator.cpp
@@ -644,7 +644,7 @@ Enumerator::Enumerator(DataDepGraph *dataDepGraph, MachineModel *machMdl,
   }
 
   histTableInitTime = Utilities::GetProcessorTime() - histTableInitTime;
-  stats::historyTableInitializationTime.Record(histTableInitTime);
+  //stats::historyTableInitializationTime.Record(histTableInitTime);
 
   tightndLst_ = NULL;
   bkwrdTightndLst_ = NULL;
@@ -1412,7 +1412,7 @@ bool Enumerator::ProbeBranch_(SchedInstruction *inst, EnumTreeNode *&newNode,
 #ifdef IS_DEBUG_INFSBLTY_TESTS
       stats::forwardLBInfeasibilityHits++;
 #endif
-      stats::forwardLBInfeasibilityHits++;
+      //stats::forwardLBInfeasibilityHits++;
 #ifdef IS_DEBUG_SEARCH_ORDER
       Logger::Log((Logger::LOG_LEVEL) 4, false, "probe: LB fail");
 #endif
@@ -1422,7 +1422,7 @@ bool Enumerator::ProbeBranch_(SchedInstruction *inst, EnumTreeNode *&newNode,
 #ifdef IS_DEBUG_INFSBLTY_TESTS
       stats::backwardLBInfeasibilityHits++;
 #endif
-      stats::backwardLBInfeasibilityHits++;
+      //stats::backwardLBInfeasibilityHits++;
 
 #ifdef IS_DEBUG_SEARCH_ORDER
       Logger::Log((Logger::LOG_LEVEL) 4, false, "probe: deadline fail");
@@ -1444,7 +1444,7 @@ bool Enumerator::ProbeBranch_(SchedInstruction *inst, EnumTreeNode *&newNode,
   if (prune_.nodeSup) {
     if (inst != NULL) {
       if (crntNode_->WasSprirNodeExmnd(inst)) {
-        stats::nodeSuperiorityInfeasibilityHits++;
+        //stats::nodeSuperiorityInfeasibilityHits++;
       nodeSupInfsbl++;
         isNodeDmntd = true;
 #ifdef IS_DEBUG_SEARCH_ORDER
@@ -1472,7 +1472,7 @@ bool Enumerator::ProbeBranch_(SchedInstruction *inst, EnumTreeNode *&newNode,
     stats::slotCountInfeasibilityHits++;
 #endif
   if (!bbt_->isSecondPass()) Logger::Info("actually pruning due to slot count");
-  stats::slotCountInfeasibilityHits++;
+  //stats::slotCountInfeasibilityHits++;
 #ifdef IS_DEBUG_SEARCH_ORDER
     Logger::Log((Logger::LOG_LEVEL) 4, false, "probe: issue slot fail");
 #endif
@@ -1489,7 +1489,7 @@ bool Enumerator::ProbeBranch_(SchedInstruction *inst, EnumTreeNode *&newNode,
     stats::rangeTighteningInfeasibilityHits++;
 #endif
   if (!bbt_->isSecondPass()) Logger::Info("actually pruning due to rng tightn");
-  stats::rangeTighteningInfeasibilityHits++;
+  //stats::rangeTighteningInfeasibilityHits++;
 
 #ifdef IS_DEBUG_SEARCH_ORDER
     Logger::Log((Logger::LOG_LEVEL) 4, false, "probe: tightn LB fail");
@@ -1515,7 +1515,7 @@ bool Enumerator::ProbeBranch_(SchedInstruction *inst, EnumTreeNode *&newNode,
 #ifdef IS_DEBUG_INFSBLTY_TESTS
         stats::historyDominationInfeasibilityHits++;
 #endif
-  stats::historyDominationInfeasibilityHits++;
+  //stats::historyDominationInfeasibilityHits++;
 #ifdef IS_DEBUG_SEARCH_ORDER
         Logger::Log((Logger::LOG_LEVEL) 4, false, "probe: histDom fail");
 #endif
@@ -1536,7 +1536,7 @@ bool Enumerator::ProbeBranch_(SchedInstruction *inst, EnumTreeNode *&newNode,
       stats::relaxedSchedulingInfeasibilityHits++;
 #endif
     if (!bbt_->isSecondPass()) Logger::Info("actually pruning due to rlx schd");
-  stats::relaxedSchedulingInfeasibilityHits++;
+  //stats::relaxedSchedulingInfeasibilityHits++;
 
       isRlxInfsbl = true;
 #ifdef IS_DEBUG_SEARCH_ORDER
@@ -2166,7 +2166,7 @@ bool Enumerator::WasDmnntSubProbExmnd_(SchedInstruction *,
   int listSize = exmndSubProbs_->GetListSize(newNode->GetSig());
 
   UDT_HASHVAL key = exmndSubProbs_->HashKey(newNode->GetSig());
-  stats::historyListSize.Record(listSize);
+  //stats::historyListSize.Record(listSize);
   if (listSize == 0) return false;
   mostRecentMatchingHistNode_ = nullptr;
   bool mostRecentMatchWasSet = false;
@@ -2203,7 +2203,7 @@ bool Enumerator::WasDmnntSubProbExmnd_(SchedInstruction *,
         exNode->PrntPartialSched(Logger::GetLogStream());
 #endif
 
-        stats::positiveDominationHits++;
+        //stats::positiveDominationHits++;
 #ifdef IS_DEBUG_SPD
         stats::positiveDominationHits++;
         stats::traversedHistoryListSize.Record(trvrsdListSize);
@@ -2239,7 +2239,7 @@ bool Enumerator::WasDmnntSubProbExmnd_(SchedInstruction *,
 
   
 
-  stats::traversedHistoryListSize.Record(trvrsdListSize);
+  //stats::traversedHistoryListSize.Record(trvrsdListSize);
   return wasDmntSubProbExmnd;
 }
 /****************************************************************************/
@@ -2567,7 +2567,7 @@ void Enumerator::PrintLog_() {
   Logger::Info("Total nodes examined: %lld\n", GetNodeCnt());
   Logger::Info("History table includes %d entries.\n",
                exmndSubProbs_->GetEntryCnt());
-  Logger::GetLogStream() << stats::historyEntriesPerIteration;
+  //Logger::GetLogStream() << stats::historyEntriesPerIteration;
   Logger::Info("--------------------------------------------------\n");
 }
 /*****************************************************************************/
@@ -2895,7 +2895,7 @@ bool LengthCostEnumerator::ProbeBranch_(SchedInstruction *inst,
 #ifdef IS_DEBUG_INFSBLTY_TESTS
       stats::historyDominationInfeasibilityHits++;
 #endif
-  stats::historyDominationInfeasibilityHits;
+  //stats::historyDominationInfeasibilityHits;
       bbt_->unschdulInst(inst, crntCycleNum_, crntSlotNum_, parent);
 #ifdef IS_DEBUG_SEARCH_ORDER
       Logger::Log((Logger::LOG_LEVEL) 4, false, "probe: LCE history fail");
@@ -2926,7 +2926,7 @@ bool LengthCostEnumerator::ChkCostFsblty_(SchedInstruction *inst,
     isFsbl = bbt_->chkCostFsblty(trgtSchedLngth_, newNode, !trueState);
 
     if (!isFsbl && trueState) {
-      stats::costInfeasibilityHits++;
+      //stats::costInfeasibilityHits++;
 #ifdef IS_DEBUG_FLOW
       Logger::Info("Detected cost infeasibility of inst %d in cycle %d",
                    inst == NULL ? -2 : inst->GetNum(), crntCycleNum_);
@@ -3617,7 +3617,7 @@ void LengthCostEnumerator::unschedulePrefixInst_(SchedInstruction *instToUnschdu
   costStack.pop();
   bbt_->unschdulInstAndRevert(instToUnschdul, crntCycleNum_, crntSlotNum_, tempCost);
   rdyLst_->RemoveLatestSubList();
-  rdyLst_->AddInst(instToUnschdul);
+  rdyLst_->AddInst(instToUnschdul, bbt_);
   MovToPrevSlot_(crntSlotNum_);
   ConstrainedScheduler::UnSchdulInst_(instToUnschdul);
   instToUnschdul->UnSchedule(SolverID_);
@@ -3764,7 +3764,7 @@ void LengthCostEnumerator::getRdyListAsNodes(std::pair<EnumTreeNode *, unsigned 
 
 
     pool->push(std::make_pair(allocAndInitNextNode(nxtInst, node, pushNode, node->GetRdyLst(), subPrefix), heur));
-    rdyLst_->AddInst(nxtInst.first);
+    rdyLst_->AddInst(nxtInst.first, bbt_);
   }
 
   delete[] ExploreNode->second;
@@ -3986,7 +3986,7 @@ EnumTreeNode *LengthCostEnumerator::allocAndInitNextNode(std::pair<SchedInstruct
 /*****************************************************************************/
 void LengthCostEnumerator::appendToRdyLst(LinkedList<SchedInstruction> *lst)
 {
-  rdyLst_->AddList(lst);
+  rdyLst_->AddList(lst, bbt_);
 }
 /*****************************************************************************/
 

--- a/lib/Scheduler/list_sched.cpp
+++ b/lib/Scheduler/list_sched.cpp
@@ -176,7 +176,7 @@ void ListScheduler::UpdtRdyLst_(InstCount cycleNum, int slotNum) {
   LinkedList<SchedInstruction> *lst2 = frstRdyLstPerCycle_[cycleNum];
 
   if (prirts_.isDynmc)
-    rdyLst_->UpdatePriorities();
+    rdyLst_->UpdatePriorities(bbt_);
 
   if (slotNum == 0 && prevCycleNum >= 0) {
     // If at the begining of a new cycle other than the very first cycle,
@@ -186,14 +186,14 @@ void ListScheduler::UpdtRdyLst_(InstCount cycleNum, int slotNum) {
     lst1 = frstRdyLstPerCycle_[prevCycleNum];
 
     if (lst1 != NULL) {
-      rdyLst_->AddList(lst1);
+      rdyLst_->AddList(lst1, bbt_);
       lst1->Reset();
       CleanupCycle_(prevCycleNum);
     }
   }
 
   if (lst2 != NULL) {
-    rdyLst_->AddList(lst2);
+    rdyLst_->AddList(lst2, bbt_);
     lst2->Reset();
   }
 }

--- a/lib/Scheduler/register.cpp
+++ b/lib/Scheduler/register.cpp
@@ -5,13 +5,13 @@ using namespace llvm::opt_sched;
 
 int16_t llvm::opt_sched::Register::GetType() const { return type_; }
 
-int llvm::opt_sched::Register::GetNum(int SolverID) const { return otherCachedVals[SolverID].num_; }
+int llvm::opt_sched::Register::GetNum(int SolverID) const { return num_; }
 
 int llvm::opt_sched::Register::GetWght() const { return wght_; }
 
 void llvm::opt_sched::Register::SetType(int16_t type) { type_ = type; }
 
-void llvm::opt_sched::Register::SetNum(int SolverID, int num) { otherCachedVals[SolverID].num_ = num; }
+void llvm::opt_sched::Register::SetNum(int SolverID, int num) { num_ = num; }
 
 void llvm::opt_sched::Register::setNumSolvers(int NumSolvers) {NumSolvers_ = NumSolvers; }
 
@@ -26,7 +26,7 @@ void llvm::opt_sched::Register::SetPhysicalNumber(int physicalNumber) {
 }
 
 bool llvm::opt_sched::Register::IsLive(int SolverID) const {
-  assert(cachedVals[SolverID].crntUseCnt_ <= useCnt_);
+//  assert(cachedVals[SolverID].crntUseCnt_ <= useCnt_);
   return cachedVals[SolverID].crntUseCnt_ < useCnt_;
 }
 
@@ -162,7 +162,12 @@ RegisterFile::RegisterFile() {
   physRegCnt_ = 0;
 }
 
-RegisterFile::~RegisterFile() {}
+RegisterFile::~RegisterFile() {
+//  for (int i = 0; i < Regs.size(); i++) {
+//    delete Regs[i];
+//  }
+//  delete[] Regs;
+}
 
 int RegisterFile::GetRegCnt() const { return getCount(); }
 
@@ -188,7 +193,7 @@ llvm::opt_sched::Register *RegisterFile::getNext() {
   size_t RegNum = Regs.size();
   // TODO
   //auto Reg = llvm::make_unique<Register>(NumSolvers_);
-  auto Reg = std::unique_ptr<llvm::opt_sched::Register>(new llvm::opt_sched::Register(NumSolvers_));
+  auto Reg = std::shared_ptr<llvm::opt_sched::Register>(new llvm::opt_sched::Register(NumSolvers_));
   Reg->setNumSolvers(NumSolvers_);
   Reg->SetType(regType_);
   for (int i = 0; i < NumSolvers_; i++)
@@ -204,7 +209,7 @@ void RegisterFile::SetRegCnt(int regCnt) {
   Regs.resize(regCnt);
   for (int i = 0; i < getCount(); i++) {
     //auto Reg = llvm::make_unique<Register>();
-    auto Reg = std::unique_ptr<llvm::opt_sched::Register>(new llvm::opt_sched::Register(NumSolvers_));
+    auto Reg = std::shared_ptr<llvm::opt_sched::Register>(new llvm::opt_sched::Register(NumSolvers_));
     Reg->SetType(regType_);
     for (int j = 0; j < NumSolvers_; j++)
       Reg->SetNum(j, i);

--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -1,3 +1,4 @@
+#include "opt-sched/Scheduler/bb_thread.h"
 #include "opt-sched/Scheduler/sched_basic_data.h"
 #include "opt-sched/Scheduler/register.h"
 #include "opt-sched/Scheduler/stats.h"
@@ -1048,16 +1049,23 @@ void SchedInstruction::SetPrdcsrNums_() {
   assert(prdcsrNum == GetPrdcsrCnt());
 }
 
-int16_t SchedInstruction::CmputLastUseCnt(int SolverID) {
+int16_t SchedInstruction::CmputLastUseCnt(int SolverID, BBThread *Rgn) {
   DynamicFields_[SolverID].setLastUseCnt(0);
 
   for (int i = 0; i < useCnt_; i++) {
     Register *reg = uses_[i];
-    if (reg) 
-     assert(reg->GetCrntUseCnt(SolverID) < reg->GetUseCnt());
+    auto Fields = Rgn->getRegFields(reg);
+    int RegCrntUseCnt = Fields.CrntUseCnt;
+    if (reg)  {
+    if (RegCrntUseCnt >= reg->GetUseCnt()) {
+      errs() << "Bad condition on Reg " << reg->GetNum() << "\n";
+      errs() << "CrntUseCnt: " << RegCrntUseCnt << ", useCnt: " << reg->GetUseCnt() << "\n";
+      assert(false);
+    }
+    }
     
     
-    if (reg->GetCrntUseCnt(SolverID) + 1 == reg->GetUseCnt())
+    if (RegCrntUseCnt + 1 == reg->GetUseCnt())
       DynamicFields_[SolverID].setLastUseCnt(DynamicFields_[SolverID].getLastUseCnt()+1);
   }
 

--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -156,10 +156,13 @@ SchedInstruction::SchedInstruction(InstCount num, const string &name,
 
 SchedInstruction::~SchedInstruction() {
 
-  delete[] DynamicFields_;
+// delete DynamicFields_;
   
   if (memAllocd_)
     DeAllocMem_();
+
+ delete[] DynamicFields_;
+
 
 }
 
@@ -169,9 +172,10 @@ void SchedInstruction::resetThreadWriteFields(int SolverID, bool full) {
   if (SolverID == -1) {  
     for (int SolverID_ = 0; SolverID_ < NumSolvers_; SolverID_++) {
       DynamicFields_[SolverID].reset(prdcsrCnt_, scsrCnt_);
-      if (sortedPrdcsrLst_ != NULL) 
-        if (sortedPrdcsrLst_[SolverID_] != NULL) 
-          delete sortedPrdcsrLst_[SolverID_]; 
+      if (sortedPrdcsrLst_ != NULL)
+        if (sortedPrdcsrLst_[SolverID_] != NULL)
+          delete sortedPrdcsrLst_[SolverID_];
+
       //if (rdyCyclePerPrdcsr_ != NULL) 
       //  if (rdyCyclePerPrdcsr_[SolverID_] != NULL) 
       //    delete[] rdyCyclePerPrdcsr_[SolverID_]; 
@@ -190,7 +194,7 @@ void SchedInstruction::resetThreadWriteFields(int SolverID, bool full) {
     if (sortedPrdcsrLst_ != NULL) 
       delete[] sortedPrdcsrLst_;
     if (sortedScsrLst_ != NULL) 
-      delete[] sortedScsrLst_;
+      delete sortedScsrLst_;
     //if (crntRange_ != NULL)
     //  delete[] crntRange_;
     
@@ -271,9 +275,6 @@ void SchedInstruction::resetThreadWriteFields(int SolverID, bool full) {
 
 
     if (full) {
-      if (sortedPrdcsrLst_ != NULL) 
-        if (sortedPrdcsrLst_[SolverID] != NULL) 
-          delete sortedPrdcsrLst_[SolverID]; 
 
       sortedPrdcsrLst_[SolverID] = new PriorityList<SchedInstruction>;
 
@@ -381,7 +382,9 @@ bool SchedInstruction::InitForSchdulng(int SolverID, InstCount schedLngth,
 
 void SchedInstruction::AllocMem_(InstCount instCnt, bool isCP_FromScsr,
                                  bool isCP_FromPrdcsr) {
-  
+  isCP_FromScsr_ = isCP_FromScsr;
+  isCP_FromPrdcsr_ = isCP_FromPrdcsr;
+
   // Thread dependent structures
   // TODO: cacheline dep, combine to struct
   //ready_ = new bool[NumSolvers_];
@@ -458,30 +461,16 @@ void SchedInstruction::AllocMem_(InstCount instCnt, bool isCP_FromScsr,
 void SchedInstruction::DeAllocMem_() {
   assert(memAllocd_);
 
-  for (int SolverID = 0; SolverID < NumSolvers_; SolverID++) {
-    if (DynamicFields_ != NULL)
-      DynamicFields_[SolverID].deallocMem();
-    if (sortedPrdcsrLst_ != NULL)
-      if (sortedPrdcsrLst_[SolverID] != NULL)
-        delete sortedPrdcsrLst_[SolverID];
-    //if (rdyCyclePerPrdcsr_ != NULL)
-    //  if (rdyCyclePerPrdcsr_[SolverID] != NULL)
-    //    delete[] rdyCyclePerPrdcsr_[SolverID];
-    //if (prevMinRdyCyclePerPrdcsr_ != NULL)
-    //  if (prevMinRdyCyclePerPrdcsr_[SolverID] != NULL)
-    //    delete[] prevMinRdyCyclePerPrdcsr_[SolverID];
-  }
-
   //if (rdyCyclePerPrdcsr_ != NULL)
   //  delete[] rdyCyclePerPrdcsr_;
   //if (prevMinRdyCyclePerPrdcsr_ != NULL)
-  //  delete[] prevMinRdyCyclePerPrdcsr_;
+  //  delete[] presortedPrdcsrLst_vMinRdyCyclePerPrdcsr_;
   if (sortedPrdcsrLst_ != NULL)
     delete[] sortedPrdcsrLst_;
   if (sortedScsrLst_ != NULL)
-    delete[] sortedScsrLst_;
+    delete sortedScsrLst_;
   if (crntRange_ != NULL)
-    delete[] crntRange_;
+    delete crntRange_;
 
   if (ltncyPerPrdcsr_ != NULL)
     delete[] ltncyPerPrdcsr_;
@@ -504,6 +493,19 @@ void SchedInstruction::DeAllocMem_() {
   //if (unschduldPrdcsrCnt_ != NULL)
   //  delete[] unschduldPrdcsrCnt_;
 
+
+
+/*
+  if (isCP_FromScsr_) {
+    delete[] crtclPathFrmRcrsvScsr_;
+    isCP_FromScsr_ = false;
+  }
+
+  if (isCP_FromPrdcsr_) {
+    delete[] crtclPathFrmRcrsvPrdcsr_;
+    isCP_FromPrdcsr_ = false;
+  }
+*/
   memAllocd_ = false;
 
 }

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -84,6 +84,9 @@ SchedRegion::SchedRegion(MachineModel *machMdl, DataDepGraph *dataDepGraph,
                          SchedPriorities hurstcPrirts,
                          SchedPriorities enumPrirts, bool vrfySched,
                          Pruning PruningStrategy, SchedulerType HeurSchedType,
+                         SmallVector<MemAlloc<EnumTreeNode> *, 16> &EnumNodeAllocs,
+                         SmallVector<MemAlloc<CostHistEnumTreeNode> *, 16> &HistNodeAllocs, 
+                         SmallVector<MemAlloc<BinHashTblEntry<HistEnumTreeNode>> *, 16> &HashTablAllocs,
                          SPILL_COST_FUNCTION spillCostFunc) {
   machMdl_ = machMdl;
   dataDepGraph_ = dataDepGraph;
@@ -109,6 +112,10 @@ SchedRegion::SchedRegion(MachineModel *machMdl, DataDepGraph *dataDepGraph,
   spillCostFunc_ = spillCostFunc;
 
   OptimalSolverID_ = new int;  
+
+  EnumNodeAllocs_ = EnumNodeAllocs;
+  HistNodeAllocs_ = HistNodeAllocs;
+  HashTablAllocs_ = HashTablAllocs;
   
   DumpDDGs_ = GetDumpDDGs();
   DDGDumpPath_ = GetDDGDumpPath();
@@ -793,7 +800,7 @@ FUNC_RESULT SchedRegion::Optimize_(Milliseconds startTime,
   InstCount initCost = bestCost_;
   
   Milliseconds timeout = IsTimeoutPerInst_ ? lngthTimeout : rgnTimeout;
-  enumrtr = AllocEnumrtr_(timeout);
+  enumrtr = AllocEnumrtr_(timeout, EnumNodeAllocs_, HistNodeAllocs_, HashTablAllocs_);
   
   if (enumrtr) {
     //#ifndef IS_TRACK_INFSBLTY_HITS

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -348,6 +348,8 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
       *OptimalSolverID_ = 0;
     }
 
+    static_cast<BBInterfacer *>(this)->resetRegFields();
+
     FinishHurstc_();
 
     Logger::Event("HeuristicResult", "length", heuristicScheduleLength, //
@@ -524,9 +526,11 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     Milliseconds enumStart = Utilities::GetProcessorTime();
     if (!isLstOptml) {
       dataDepGraph_->SetHard(true);
-      if (isSecondPass_ && dataDepGraph_->GetMaxLtncy() <= 1)
+      if (isSecondPass_ && dataDepGraph_->GetMaxLtncy() <= 1) {
+        *OptimalSolverID_ = 0;
         Logger::Info("Problem size not increased after introducing latencies, "
                      "skipping second pass enumeration");
+      }
       else
         rslt = Optimize_(enumStart, rgnTimeout, lngthTimeout, OptimalSolverID_);
       Milliseconds enumTime = Utilities::GetProcessorTime() - enumStart;

--- a/lib/Wrapper/OptSchedDDGWrapperBasic.h
+++ b/lib/Wrapper/OptSchedDDGWrapperBasic.h
@@ -48,11 +48,11 @@ public:
   /// Dump Optsched register def/use information for the region.
   void dumpOptSchedRegisters() const;
 
-  void convertSUnits(bool IgnoreRealEdges, bool IgnoreArtificialEdges);
+  void convertSUnits(bool IgnoreRealEdges, bool IgnoreArtificialEdges) override;
   void addArtificialEdges();
-  void convertRegFiles();
+  void convertRegFiles() override;
 
-  int getSize();
+  int getSize() override;
 
 protected:
   // A convenience machMdl_ pointer casted to OptSchedMachineModel*.

--- a/lib/Wrapper/OptSchedMachineWrapper.h
+++ b/lib/Wrapper/OptSchedMachineWrapper.h
@@ -61,7 +61,7 @@ public:
   CortexA7MMGenerator(const llvm::ScheduleDAGInstrs *dag, MachineModel *mm);
   // Generate instruction scheduling type for all instructions in the current
   // DAG by using LLVM itineraries.
-  InstType generateInstrType(const llvm::MachineInstr *instr);
+  InstType generateInstrType(const llvm::MachineInstr *instr) override;
   virtual ~CortexA7MMGenerator() = default;
 
 private:

--- a/lib/Wrapper/OptimizingScheduler.h
+++ b/lib/Wrapper/OptimizingScheduler.h
@@ -12,7 +12,10 @@
 #include "opt-sched/Scheduler/OptSchedTarget.h"
 #include "opt-sched/Scheduler/config.h"
 #include "opt-sched/Scheduler/data_dep.h"
+#include "opt-sched/Scheduler/enumerator.h"
 #include "opt-sched/Scheduler/graph_trans.h"
+#include "opt-sched/Scheduler/hist_table.h"
+#include "opt-sched/Scheduler/mem_mngr.h"
 #include "opt-sched/Scheduler/sched_region.h"
 #include "OptSchedMachineWrapper.h"
 #include "opt-sched/Scheduler/bb_thread.h"
@@ -22,6 +25,7 @@
 #include <chrono>
 #include <memory>
 #include <vector>
+#include <fstream>
 
 using namespace llvm;
 
@@ -229,6 +233,11 @@ protected:
   // What list scheduler should be used to find an initial feasible schedule.
   SchedulerType HeurSchedType;
 
+  SmallVector<MemAlloc<EnumTreeNode> *, 16> EnumNodeAllocs;
+  SmallVector<MemAlloc<CostHistEnumTreeNode> *, 16> HistNodeAllocs;
+  SmallVector<MemAlloc<BinHashTblEntry<HistEnumTreeNode>> *, 16> HashTablAllocs;
+
+
   // Load config files for the OptScheduler and set flags
   void loadOptSchedConfig();
 
@@ -285,6 +294,7 @@ public:
   ScheduleDAGOptSched(MachineSchedContext *C,
                       std::unique_ptr<MachineSchedStrategy> S);
 
+  ~ScheduleDAGOptSched(); 
   // The fallback LLVM scheduler
   void fallbackScheduler();
 


### PR DESCRIPTION
1. clean up the bulk of the warnings seen when building on Optimizer-AMD
2. Pull allocators out of the enumerator, and into the main scheduler class -- this allows for better memory management as we have memory preserved over all regions for both scheduling passes (as opposed to just one pass for one region)
3. Disable post processing the history table -- tons of cycles spent walking over the history table after scheduling and doing nothing
4. Disable stats::tracking, this is shared data across threads and is causing major caching problems